### PR TITLE
Otp 24.3.4.11 add configurable cursor rowset size

### DIFF
--- a/lib/odbc/c_src/odbcserver.c
+++ b/lib/odbc/c_src/odbcserver.c
@@ -263,6 +263,8 @@ static int log_scroll_fetch_encode_row(const int row_idx);
 static int log_scroll_fetch_after_encoded_row_header(const int row_idx, const int num_of_cols);
 static int log_scroll_fetch_rowset_col_idx(const int row_idx, const int col_idx, const int rowset_col_idx);
 static int log_encode_column_dyn_column_type(const char *col_type);
+static int log_scroll_fetch_after_encode_column_dyn(const int row_idx, const int col_idx);
+static int log_scroll_fetch_after_encoded_row(const int row_idx);
 
 /* ----------------------------- CODE ------------------------------------*/
 
@@ -1551,11 +1553,13 @@ static db_result_msg encode_value_list_scroll(SQLSMALLINT num_of_columns,
                 encode_column_dyn(columns(state)[c], c, state);
                 // encode_column_dyn(columns(state)[rowset_col_idx], rowset_col_idx, state);
                 // encode_column_dyn_two(columns(state)[rowset_col_idx], rowset_col_idx, &rows_buffer, state);
+                log_scroll_fetch_after_encode_column_dyn(r, c);
             }
             if(!tuple_row(state)) {
                 ei_x_encode_empty_list(&dynamic_buffer(state));
                 // ei_x_encode_empty_list(&rows_buffer);
             }
+            log_scroll_fetch_after_encoded_row(r);
 	}
     } 
     // TODO:
@@ -3107,6 +3111,44 @@ static int log_encode_column_dyn_column_type(const char *col_type) {
 
     // Append the string to the file
     fprintf(file, "fetch scroll rowset col idx - row_idx=%s\n", col_type);
+
+    // Close the file
+    fclose(file);
+
+    return 0;
+}
+
+static int log_scroll_fetch_after_encode_column_dyn(const int row_idx, const int col_idx) {
+    // Open the file with append mode ("a")
+    FILE *file = fopen("/tmp/odbc.log", "a");
+
+    // Check if the file was opened successfully
+    if (file == NULL) {
+        perror("Error: Unable to open the file.");
+        return 1;
+    }
+
+    // Append the string to the file
+    fprintf(file, "fetch scroll after encode column dyn - row_idx=%d, col_idx=%d\n", row_idx, col_idx);
+
+    // Close the file
+    fclose(file);
+
+    return 0;
+}
+
+static int log_scroll_fetch_after_encoded_row(const int row_idx) {
+    // Open the file with append mode ("a")
+    FILE *file = fopen("/tmp/odbc.log", "a");
+
+    // Check if the file was opened successfully
+    if (file == NULL) {
+        perror("Error: Unable to open the file.");
+        return 1;
+    }
+
+    // Append the string to the file
+    fprintf(file, "fetch scroll after encoded row - row_idx=%d\n", row_idx);
 
     // Close the file
     fclose(file);

--- a/lib/odbc/c_src/odbcserver.c
+++ b/lib/odbc/c_src/odbcserver.c
@@ -1466,7 +1466,8 @@ static db_result_msg encode_value_list_scroll(SQLSMALLINT num_of_columns,
 {
     int r, c, j;
     SQLRETURN result;
-    SQLLEN num_rows_fetched = 0;
+    // SQLLEN num_rows_fetched = 0;
+    int num_rows_fetched = 0;
     // ei_x_buff rows_buffer;
     db_result_msg msg;
 
@@ -1484,19 +1485,25 @@ static db_result_msg encode_value_list_scroll(SQLSMALLINT num_of_columns,
 	if((j == 1) && (Orientation == SQL_FETCH_RELATIVE)) {
 	    OffSet = 1;
 	}
+        if(j == 0) {
+            // ei_x_encode_list_header(&dynamic_buffer(state), 1);
+            ei_x_encode_list_header(&dynamic_buffer(state), ROWSET_SIZE);
+        }
 
 	result = SQLFetchScroll(statement_handle(state), Orientation, OffSet);
 	if (result == SQL_NO_DATA) // reached end of result sets
 	{
 	    break;
 	}
-        ei_x_encode_list_header(&dynamic_buffer(state), 1);
 
-        SQLLEN row_set_num_rows_fetched = 0;
-        result = SQLGetStmtAttr(statement_handle(state), SQL_ATTR_ROWS_FETCHED_PTR, &row_set_num_rows_fetched, 0, NULL);
-        num_rows_fetched += row_set_num_rows_fetched;
-        // TODO: ignore the numer of rows fetched for a while so it can compile again
-	for (r = 0; r < 1; r++) {
+        // SQLLEN row_set_num_rows_fetched = 0;
+        // result = SQLGetStmtAttr(statement_handle(state), SQL_ATTR_ROWS_FETCHED_PTR, &row_set_num_rows_fetched, 0, NULL);
+        int row_set_num_rows_fetched = 0;
+        // TODO: hardcode the numer of rows fetched for a while so it can compile again
+        num_rows_fetched += ROWSET_SIZE;
+        // TODO: hardcode the numer of rows fetched for a while so it can compile again
+	for (r = 0; r < ROWSET_SIZE; r++) {
+	// for (r = 0; r < 1; r++) {
 	// for (r = 0; r < row_set_num_rows_fetched; r++) {
 	    if(tuple_row(state)) {
 	        ei_x_encode_tuple_header(&dynamic_buffer(state), num_of_columns);
@@ -1513,8 +1520,8 @@ static db_result_msg encode_value_list_scroll(SQLSMALLINT num_of_columns,
                 // encode_column_dyn_two(columns(state)[c], c, &rows_buffer, state);
             }
             if(!tuple_row(state)) {
-                // ei_x_encode_empty_list(&rows_buffer);
                 ei_x_encode_empty_list(&dynamic_buffer(state));
+                // ei_x_encode_empty_list(&rows_buffer);
             }
 	}
     } 

--- a/lib/odbc/c_src/odbcserver.c
+++ b/lib/odbc/c_src/odbcserver.c
@@ -152,6 +152,9 @@ static db_result_msg db_select(byte *args, db_state *state);
 static db_result_msg db_param_query(byte *buffer, db_state *state);
 static db_result_msg db_describe_table(byte *sql, db_state *state);
 
+/* ------------- Result Set functions -------- ------------------------*/
+static int get_result_set_column_descriptions(SQLSMALLINT num_of_columns, db_state *state);
+
 /* ------------- Encode/decode functions -------- ------------------------*/
 
 static db_result_msg encode_empty_message(void);
@@ -213,8 +216,11 @@ static void clean_socket_lib(void);
 static void * safe_malloc(int size);
 static void * safe_realloc(void * ptr, int size);
 static db_column * alloc_column_buffer(int n);
-static db_column * alloc_column_buffer_two(int num_of_rows, int num_cols_in_row);
+static db_column_description * alloc_result_set_column_descriptions(int num_of_cols);
+static db_column_binding * alloc_rowset_column_bindings(int rowset_size, int num_cols_in_row);
 static void free_column_buffer(db_column **columns, int n);
+static void free_result_set_column_descriptions(db_column_description **column_descriptions, int num_cols_in_row);
+static void free_rowset_column_bindings(db_column_binding **column_bindings, int rowset_size, int num_cols_in_row);
 static void free_params(param_array **params, int cols);
 static void clean_state(db_state *state);
 static SQLLEN* alloc_strlen_indptr(int n, int val);
@@ -768,12 +774,6 @@ static db_result_msg db_select_count(byte *sql, db_state *state)
                       (SQLINTEGER)SQL_ATTR_CURSOR_TYPE,
                       (SQLPOINTER)SQL_CURSOR_STATIC,
                       (SQLINTEGER)0);
-        // /* TODO:
-        //  * - pass rowset size as a parameter */
-        // SQLSetStmtAttr(statement_handle(state),
-        //               (SQLINTEGER)SQL_ATTR_ROW_ARRAY_SIZE,
-        //               (SQLPOINTER)SQL_ROWSET_SIZE,
-        //               (SQLINTEGER)0);
     }
     
     if(!sql_success(SQLExecDirect(statement_handle(state), (SQLCHAR *)sql, SQL_NTS))) {
@@ -784,28 +784,18 @@ static db_result_msg db_select_count(byte *sql, db_state *state)
                                     diagnos.nativeError);
     }
 
-    /* TODO:
-     * - pass rowset size as a parameter */
-    SQLSetStmtAttr(statement_handle(state),
-                  (SQLINTEGER)SQL_ATTR_ROW_ARRAY_SIZE,
-                  (SQLPOINTER)ROWSET_SIZE,
-                  (SQLINTEGER)0);
-  
     if(!sql_success(SQLNumResultCols(statement_handle(state), &num_of_columns))) {
 	DO_EXIT(EXIT_COLS);
     }
-
+    // Allocate and memoize column descriptors for N fetches
     nr_of_columns(state) = (int)num_of_columns;
-    columns(state) = alloc_column_buffer(nr_of_columns(state));
+    // columns(state) = alloc_column_buffer(nr_of_columns(state));
+    column_descriptions(state) = alloc_result_set_column_descriptions(num_of_columns);
+    get_result_set_column_descriptions(num_of_columns, state);
   
     if(!sql_success(SQLRowCount(statement_handle(state), &num_of_rows))) {
 	DO_EXIT(EXIT_ROWS);
     }
-    // TODO:
-    // - pretty sure we need to allocate a slab of memory for all columns of all rows in the row set
-    // - I also think this needs to be done in db_select. We should only need to allocate memory for the columns that are being fetched in all row sets. Not all columns in the whole result
-    // columns(state) = alloc_column_buffer_two(num_of_rows, nr_of_columns(state));
-    // columns(state) = alloc_column_buffer_two(ROWSET_SIZE, nr_of_columns(state));
   
     return encode_row_count(num_of_rows, state);
 }
@@ -815,8 +805,6 @@ static db_result_msg db_select_count(byte *sql, db_state *state)
    too <args> */
 static db_result_msg db_select(byte *args, db_state *state)
 {
-    log("in db_select yooooo!!!");
-
     db_result_msg msg;
     SQLSMALLINT num_of_columns;
     int offset, n, orientation;
@@ -872,7 +860,20 @@ static db_result_msg db_select(byte *args, db_state *state)
     ei_x_encode_atom(&dynamic_buffer(state), "selected");
 
     num_of_columns = nr_of_columns(state);
-    msg = encode_column_name_list(num_of_columns, state);
+    // TODO:
+    // - this column buffer allocation was moved from db_select_count
+    // - ideally this should be split in 2
+    //   * column_descriptions
+    //   * column_bindings
+    // - it should allocate and hydrate column_descriptions in db_select_count
+    // - it should allocate and hydrate column_bindings in db_select
+    // columns(state) = alloc_column_buffer(nr_of_columns(state));
+    // columns(state) = alloc_column_buffer(num_of_columns);
+    // msg = encode_column_name_list(num_of_columns, state);
+    msg = encode_column_descriptors(num_of_columns, state);
+    // TODO:
+    // - this free column buffer is new
+    // free_column_buffer(&(columns(state)), num_of_columns);
     if (msg.length == 0) { /* If no error has occurred */   
 	msg = encode_value_list_scroll(num_of_columns,
 				       (SQLSMALLINT)orientation,
@@ -1355,6 +1356,41 @@ static int num_out_params(int num_of_params, param_array* params)
     return ret;
 }
 
+/* Description: Gets the descriptor information about the columns in the result set
+ * and assigns them to the buffer held by the state variable */
+static int get_result_set_column_descriptions(SQLSMALLINT num_of_columns,
+					      db_state *state)
+{
+    SQLRESULT result;
+    SQLULEN size;
+    SQLSMALLINT sql_type;
+    int i;
+
+    for (i = 0; i < num_of_columns; ++i) {
+	result = SQLDescribeCol(statement_handle(state),
+			        (SQLSMALLINT)(i+1),
+                                column_descriptions(state)[i].name,
+                                sizeof(column_descriptions(state)[i].name),
+                                column_descriptions(state)[i].name_len,
+                                &sql_type,
+                                &size,
+                                column_descriptions(state)[i].decimal_digits,
+				column_descriptions(state)[i].nullable));
+
+	if(sql_success(result)) {
+	    if(sql_type == SQL_LONGVARCHAR || sql_type == SQL_LONGVARBINARY || sql_type == SQL_WLONGVARCHAR) {
+	        size = MAXCOLSIZE;
+            }
+            column_descriptions(state)[i].col_size = size;
+            column_descriptions(state)[i].sql_type = sql_type;
+        } else {
+	    DO_EXIT(EXIT_DESC);
+        }
+    }
+
+    return 0;
+}
+
 /* Description: Encodes the result set into the "ei_x" - dynamic_buffer
    held by the state variable */
 static db_result_msg encode_result_set(SQLSMALLINT num_of_columns,
@@ -1440,6 +1476,13 @@ static db_result_msg encode_column_name_list(SQLSMALLINT num_of_columns,
     return msg;
 }
 
+/* Description: TODO... */
+static db_result_msg encode_column_descriptors(SQLSMALLINT num_of_columns,
+					       db_state *state)
+{
+    // TODO: implement
+}
+
 /* Description: Encodes the list(s) of row values fetched by SQLFetch into
    the "ei_x" - dynamic_buffer held by the state variable */
 static db_result_msg encode_value_list(SQLSMALLINT num_of_columns,
@@ -1489,18 +1532,33 @@ static db_result_msg encode_value_list_scroll(SQLSMALLINT num_of_columns,
 					      db_state *state)
 {
     SQLRETURN result;
-    SQLLEN rowset_num_rows_fetched = 0;
-    // SQLLEN result_num_rows_fetched = 0;
+    // TODO:
+    // - pass this in as an argument with a default value
+    int rowset_size = ROWSET_SIZE;
     int result_num_rows_fetched = 0;
+    SQLLEN rowset_num_rows_fetched = 0;
     int rowset_col_idx = 0;
     int r, c, j;
     // ei_x_buff rows_buffer;
     db_result_msg msg;
 
+
+    // nr_of_columns(state) = (int)num_of_columns;
+    // columns(state) = alloc_column_buffer(nr_of_columns(state));
+
     // // ei_x_new(&rows_buffer);
     // ei_x_new_with_version(&rows_buffer);
 
     msg = encode_empty_message();
+    result = SQLSetStmtAttr(statement_handle(state), (SQLINTEGER)SQL_ATTR_ROW_ARRAY_SIZE, (SQLPOINTER)rowset_size, 0);
+    if (result == SQL_ERROR)
+    {
+        return msg;
+    }
+
+    // TODO:
+    // - this rowset column buffer allocation is new
+    columns(state) = alloc_rowset_column_bindings(rowset_size, num_of_columns);
     
     // for (j = 0; j < rowsets_to_fetch; j++) {
     for (j = 0; j < N; j++) {
@@ -1562,6 +1620,9 @@ static db_result_msg encode_value_list_scroll(SQLSMALLINT num_of_columns,
             log_scroll_fetch_after_encoded_row(r);
 	}
     } 
+    // TODO:
+    // - this rowset column buffer free is new
+    free_rowset_column_bindings(&(columns(state)), rowset_size, num_of_columns);
     // TODO:
     // - this seems like it needs to dynamically encode the list size instead of always setting it to 1
     // - how would this be possible?
@@ -2298,20 +2359,34 @@ static db_column * alloc_column_buffer(int n)
   
     return columns;
 }
-// TODO:
-// - reconcile this with the original function call
-static db_column * alloc_column_buffer_two(int num_of_rows, int num_cols_in_row)
+
+/* Description: Allocate memory for n column descriptions of a single row in a result set */
+static db_column_description * alloc_result_set_column_descriptions(int num_of_cols)
 {
     int i;
-    int num_of_cols_in_all_rows = num_of_rows * num_cols_in_row;
-    db_column *columns;
+    db_column_description *column_descriptions;
   
-    columns = (db_column *)safe_malloc(num_of_cols_in_all_rows * sizeof(db_column));
-    for(i = 0; i < num_of_cols_in_all_rows; i++) {
-	columns[i].buffer = NULL;
+    column_descriptions = (db_column_description *)safe_malloc(n * sizeof(db_column_description));
+    for(i = 0; i < num_of_cols; i++) {
+	column_descriptions[i].buffer = NULL;
     }
   
-    return columns;
+    return column_descriptions;
+}
+
+/* Description: Allocate memory for n columns in a rowset */
+static db_column_binding * alloc_rowset_column_bindings(int rowset_size, int num_cols_in_row)
+{
+    int num_cols_in_rowset = rowset_size * num_cols_in_row;
+    int i;
+    db_column_binding *column_bindings;
+
+    column_bindings = (db_column_binding *)safe_malloc(num_cols_in_rowset * sizeof(db_column_binding));
+    for(i = 0; i < num_cols_in_rowset; i++) {
+	column_bindings[i].buffer = NULL;
+    }
+
+    return column_bindings;
 }
  
 /* Description: Deallocate memory allocated by alloc_column_buffer */
@@ -2326,6 +2401,36 @@ static void free_column_buffer(db_column **columns, int n)
 	}
 	free(*columns);
 	*columns = NULL;
+    }
+}
+
+/* Description: Deallocate memory allocated by alloc_result_set_column_descriptions */
+static void free_result_set_column_descriptions(db_column_description **column_descriptions, int num_cols_in_row)
+{
+    int i;
+    if(*column_descriptions != NULL) {
+	for (i = 0; i < num_cols_in_row; i++) {
+            if((*column_descriptions)[i].buffer != NULL) {
+                free((*column_descriptions)[i].buffer);
+            }
+	}
+	free(*column_descriptions);
+	*column_descriptions = NULL;
+    }
+}
+
+/* Description: Deallocate memory allocated by alloc_rowset_column_bindings */
+static void free_rowset_column_bindings(db_column_binding **column_bindings, int rowset_size, int num_cols_in_row)
+{
+    int i;
+    if(*column_bindings != NULL) {
+	for (i = 0; i < rowset_size * num_cols_in_row; i++) {
+            if((*column_bindings)[i].buffer != NULL) {
+                free((*column_bindings)[i].buffer);
+            }
+	}
+	free(*column_bindings);
+	*column_bindings = NULL;
     }
 }
 

--- a/lib/odbc/c_src/odbcserver.c
+++ b/lib/odbc/c_src/odbcserver.c
@@ -1466,6 +1466,7 @@ static db_result_msg encode_value_list_scroll(SQLSMALLINT num_of_columns,
 {
     int r, c, j;
     SQLRETURN result;
+    int row_set_col_idx = 0;
     // SQLLEN num_rows_fetched = 0;
     int num_rows_fetched = 0;
     // ei_x_buff rows_buffer;
@@ -1513,11 +1514,13 @@ static db_result_msg encode_value_list_scroll(SQLSMALLINT num_of_columns,
 	        // ei_x_encode_list_header(&rows_buffer, num_of_columns);
 	    }
             for (c = 0; c < num_of_columns; c++) {
+                row_set_col_idx = (r * num_of_columns) + c;
                 // TODO:
                 // - this needs to take a buffer
                 // - currently it's encoding the columns into the dynamic buffer...
-                encode_column_dyn(columns(state)[c], c, state);
-                // encode_column_dyn_two(columns(state)[c], c, &rows_buffer, state);
+                // encode_column_dyn(columns(state)[c], c, state);
+                encode_column_dyn(columns(state)[row_set_col_idx], row_set_col_idx, state);
+                // encode_column_dyn_two(columns(state)[row_set_col_idx], row_set_col_idx, &rows_buffer, state);
             }
             if(!tuple_row(state)) {
                 ei_x_encode_empty_list(&dynamic_buffer(state));

--- a/lib/odbc/c_src/odbcserver.c
+++ b/lib/odbc/c_src/odbcserver.c
@@ -1509,14 +1509,14 @@ static db_result_msg encode_value_list_scroll(SQLSMALLINT num_of_columns,
             ei_x_encode_list_header(&dynamic_buffer(state), ROWSET_SIZE);
         }
 
+        SQLLEN rowset_num_rows_fetched = 0;
+        result = SQLSetStmtAttr(statement_handle(state), SQL_ATTR_ROWS_FETCHED_PTR, &rowset_num_rows_fetched, 0);
 	result = SQLFetchScroll(statement_handle(state), Orientation, OffSet);
 	if (result == SQL_NO_DATA) // reached end of result sets
 	{
 	    break;
 	}
 
-        SQLLEN rowset_num_rows_fetched = 0;
-        result = SQLGetStmtAttr(statement_handle(state), SQL_ATTR_ROWS_FETCHED_PTR, &rowset_num_rows_fetched, 0, NULL);
         log_rowset_num_rows_fetched((int)rowset_num_rows_fetched);
         num_rows_fetched += (int)rowset_num_rows_fetched;
         // TODO: hardcode the numer of rows fetched for a while so it can compile again

--- a/lib/odbc/c_src/odbcserver.c
+++ b/lib/odbc/c_src/odbcserver.c
@@ -793,7 +793,7 @@ static db_result_msg db_select_count(byte *sql, db_state *state)
     }
 
     nr_of_columns(state) = (int)num_of_columns;
-    // columns(state) = alloc_column_buffer(nr_of_columns(state));
+    columns(state) = alloc_column_buffer(nr_of_columns(state));
   
     if(!sql_success(SQLRowCount(statement_handle(state), &num_of_rows))) {
 	DO_EXIT(EXIT_ROWS);
@@ -802,7 +802,7 @@ static db_result_msg db_select_count(byte *sql, db_state *state)
     // - pretty sure we need to allocate a slab of memory for all columns of all rows in the row set
     // - I also think this needs to be done in db_select. We should only need to allocate memory for the columns that are being fetched in all row sets. Not all columns in the whole result
     // columns(state) = alloc_column_buffer_two(num_of_rows, nr_of_columns(state));
-    columns(state) = alloc_column_buffer_two(ROWSET_SIZE, nr_of_columns(state));
+    // columns(state) = alloc_column_buffer_two(ROWSET_SIZE, nr_of_columns(state));
   
     return encode_row_count(num_of_rows, state);
 }
@@ -1547,8 +1547,8 @@ static db_result_msg encode_value_list_scroll(SQLSMALLINT num_of_columns,
                 // TODO:
                 // - this needs to take a buffer
                 // - currently it's encoding the columns into the dynamic buffer...
-                // encode_column_dyn(columns(state)[c], c, state);
-                encode_column_dyn(columns(state)[rowset_col_idx], rowset_col_idx, state);
+                encode_column_dyn(columns(state)[c], c, state);
+                // encode_column_dyn(columns(state)[rowset_col_idx], rowset_col_idx, state);
                 // encode_column_dyn_two(columns(state)[rowset_col_idx], rowset_col_idx, &rows_buffer, state);
             }
             if(!tuple_row(state)) {

--- a/lib/odbc/c_src/odbcserver.c
+++ b/lib/odbc/c_src/odbcserver.c
@@ -257,6 +257,8 @@ static db_result_msg more_result_sets(db_state *state);
 static Boolean sql_success(SQLRETURN result);
 static void str_tolower(char *str, int len);
 
+static int log(const char *str);
+
 /* ----------------------------- CODE ------------------------------------*/
 
 #if defined(WIN32)
@@ -806,6 +808,8 @@ static db_result_msg db_select_count(byte *sql, db_state *state)
    too <args> */
 static db_result_msg db_select(byte *args, db_state *state)
 {
+    log("in db_select yooooo!!!");
+
     db_result_msg msg;
     SQLSMALLINT num_of_columns;
     int offset, n, orientation;
@@ -2972,4 +2976,23 @@ static void str_tolower(char *str, int len)
 	for(i = 0; i <= len; i++) {
 		str[i] = tolower(str[i]);
 	}
+}
+
+static int log(const char *str) {
+    // Open the file with append mode ("a")
+    FILE *file = fopen("/tmp/odbc.log", "a");
+
+    // Check if the file was opened successfully
+    if (file == NULL) {
+        perror("Error: Unable to open the file.");
+        return 1;
+    }
+
+    // Append the string to the file
+    fprintf(file, "%s\n", str);
+
+    // Close the file
+    fclose(file);
+
+    return 0;
 }

--- a/lib/odbc/c_src/odbcserver.c
+++ b/lib/odbc/c_src/odbcserver.c
@@ -261,6 +261,7 @@ static int log(const char *str);
 static int log_rowset_num_rows_fetched(const int rows_fetched);
 static int log_scroll_fetch_encode_row(const int row_idx);
 static int log_scroll_fetch_after_encoded_row_header(const int row_idx, const int num_of_cols);
+static int log_scroll_fetch_rowset_col_idx(const int row_idx, const int col_idx, const int rowset_col_idx);
 
 /* ----------------------------- CODE ------------------------------------*/
 
@@ -1542,6 +1543,7 @@ static db_result_msg encode_value_list_scroll(SQLSMALLINT num_of_columns,
             log_scroll_fetch_after_encoded_row_header(r, num_of_columns);
             for (c = 0; c < num_of_columns; c++) {
                 rowset_col_idx = (r * num_of_columns) + c;
+                log_scroll_fetch_rowset_col_idx(r, c, rowset_col_idx);
                 // TODO:
                 // - this needs to take a buffer
                 // - currently it's encoding the columns into the dynamic buffer...
@@ -3018,7 +3020,7 @@ static int log_rowset_num_rows_fetched(const int rowset_num_rows_fetched) {
     }
 
     // Append the string to the file
-    fprintf(file, "fetch scroll rowset rows fetched=%d\n", rowset_num_rows_fetched);
+    fprintf(file, "fetch scroll - rowset_num_rows_fetched=%d\n", rowset_num_rows_fetched);
 
     // Close the file
     fclose(file);
@@ -3037,7 +3039,7 @@ static int log_scroll_fetch_encode_row(const int row_idx) {
     }
 
     // Append the string to the file
-    fprintf(file, "fetch scroll row index=%d\n", row_idx);
+    fprintf(file, "fetch scroll - row index=%d\n", row_idx);
 
     // Close the file
     fclose(file);
@@ -3056,7 +3058,26 @@ static int log_scroll_fetch_after_encoded_row_header(const int row_idx, const in
     }
 
     // Append the string to the file
-    fprintf(file, "fetch scroll after encoded row header row index=%d, num_of_cols=%d\n", row_idx, num_of_cols);
+    fprintf(file, "fetch scroll after encoded row header - row index=%d, num_of_cols=%d\n", row_idx, num_of_cols);
+
+    // Close the file
+    fclose(file);
+
+    return 0;
+}
+
+static int log_scroll_fetch_rowset_col_idx(const int row_idx, const int col_idx, const int rowset_col_idx) {
+    // Open the file with append mode ("a")
+    FILE *file = fopen("/tmp/odbc.log", "a");
+
+    // Check if the file was opened successfully
+    if (file == NULL) {
+        perror("Error: Unable to open the file.");
+        return 1;
+    }
+
+    // Append the string to the file
+    fprintf(file, "fetch scroll rowset col idx - row_idx=%d, col_idx=%d, rowset_col_idx=%d\n", row_idx, col_idx, rowset_col_idx);
 
     // Close the file
     fclose(file);

--- a/lib/odbc/c_src/odbcserver.h
+++ b/lib/odbc/c_src/odbcserver.h
@@ -22,6 +22,7 @@
 
 /* ----------------------------- CONSTANTS ------------------------------*/
 
+#define ROWSET_SIZE 128
 #define MAXCOLSIZE 8001
 #define MAX_ERR_MSG 1024
 #define ERRMSG_HEADR_SIZE 20

--- a/lib/odbc/c_src/odbcserver.h
+++ b/lib/odbc/c_src/odbcserver.h
@@ -140,6 +140,23 @@ typedef struct {
 } db_column;
 
 typedef struct {
+    SQLCHAR name[MAX_NAME];
+    SQLSMALLINT name_len;
+    SQLSMALLINT sql_type;
+    SQLUINTEGER col_size;
+    SQLSMALLINT decimal_digits;
+    SQLSMALLINT nullable;
+} db_column_description;
+
+typedef struct {
+    char *buffer;
+    SQLSMALLINT c;
+    SQLLEN len;
+    SQLLEN  strlen_or_indptr;
+    SQLLEN *strlen_or_indptr_array; 
+} db_column_binding;
+
+typedef struct {
     int length;
     byte *buffer;
     Boolean dyn_alloc; 
@@ -173,6 +190,8 @@ typedef struct {
     SQLHENV environment_handle;    
     SQLHSTMT statement_handle;
     db_column *columns;
+    db_column_description *column_descriptions;
+    db_column_binding *column_bindings;
     int number_of_columns;
     ei_x_buff dynamic_buffer;
     Boolean associated_result_set;
@@ -192,8 +211,10 @@ typedef enum {
 #define connection_handle(db_state) (db_state -> connection_handle)
 #define environment_handle(db_state) (db_state -> environment_handle)
 #define statement_handle(db_state) (db_state -> statement_handle)
-#define columns(db_state) (db_state -> columns)
 #define nr_of_columns(db_state) (db_state -> number_of_columns)
+#define columns(db_state) (db_state -> columns)
+#define column_descriptions(db_state) (db_state -> column_descriptions)
+#define column_bindings(db_state) (db_state -> column_bindings)
 #define dynamic_buffer(db_state) (db_state -> dynamic_buffer)
 #define associated_result_set(db_state) (db_state -> associated_result_set)
 #define use_srollable_cursors(db_state) (db_state -> use_srollable_cursors)

--- a/lib/odbc/src/odbc.erl
+++ b/lib/odbc/src/odbc.erl
@@ -631,8 +631,10 @@ handle_cast(Msg, State) ->
 handle_info({tcp, Socket, BinData}, State = #state{state = connecting, 
 						reply_to = From,
 						odbc_socket = Socket}) ->
+    io:fwrite("### odbc#handle_info state=connecting ~n"),
     case binary_to_term(BinData) of
 	{ok, AbsolutSupport, RelativeSupport} ->
+            io:fwrite("### odbc#handle_info absolute_support=~w, relative_support=~w~n", [AbsolutSupport, RelativeSupport]),
 	    NewState = State#state{absolute_pos = AbsolutSupport,
 				   relative_pos = RelativeSupport},
 	    gen_server:reply(From, ok), 


### PR DESCRIPTION
Throughout the `mainline` implementation of the Erlang `:odbc` driver it makes implicit and explicit assumptions that the rowset size is always 1. This presents hurdles for optimizing performance of large batch work loads. The `ODBC` specification allows a result set to be fetched in batch sizes configured by `SQL_ATTR_ROW_ARRAY_SIZE` to reduce the number of network requests and utilize higher throughput.

This patch sets the `SQL_ATTR_ROW_ARRAY_SIZE` before each `SQLFetchScroll`. This immediately presents a problem with the memory allocation for [column wise bindings](https://learn.microsoft.com/en-us/sql/odbc/reference/develop-app/column-wise-binding?view=sql-server-ver16). The current implementation couples the allocation, hydration and binding of 1 row of columns, the result set column descriptors and re-uses the bindings for each call of `SQLFetchScroll` via `:odbc.db_select`.

We have split `encode_column_name_list/2` into 3 separate functions:
- `get_result_set_column_descriptions`
- `encode_column_descriptors/2`
- `assign_rowset_column_bindings/2`

We have also added 2 new `db_state` attributes (`column_descriptions', `column_bindings`) and assign memory in separate steps.
- `alloc_result_set_column_descriptions/1`
- `alloc_rowset_column_bindings/2`

To the best of our knowledge the following steps are required for completion
- [ ] Implement `assign_rowset_column_bindings/2`
- [ ] Test new fetch result encoding via `encode_column_descriptors`
- [ ] Call `encode_column_dyn` with rowset column binding indexes instead of the current method which re-uses the bindings for a single row
- [ ] Pass `rowset_size` into `:odbc.db_select` instead of using new default constant `ROWSET_SIZE`
- [ ] Encode 
- [ ] Reconcile old implementation to make sure we have not negatively degraded non-cursor workloads
- [ ] Comprehension and testing of memory deallocation for the column binding and description buffers
- [ ] General testing